### PR TITLE
Fix Roxygen parsing of examples.

### DIFF
--- a/R/skrrrahh.R
+++ b/R/skrrrahh.R
@@ -20,9 +20,9 @@
 #'
 #'@return NULL 
 #'
-#'  @examples 
-#'  # Play Gucci saying "BRRR"
-#'  skrrratt()
+#' @examples 
+#' # Play Gucci saying "BRRR"
+#' skrrratt()
 #' \dontrun{
 #' # Get focused with Jay-Z.
 #' skrrrahh(29)

--- a/man/skrrrahh.Rd
+++ b/man/skrrrahh.Rd
@@ -17,12 +17,20 @@ supported.}
 
 \item{expr}{An optional expression to be excecuted before the sound.}
 }
-\value{
-NULL 
-
- @examples 
- # Play Gucci saying "BRRR"
- skrrratt()
+\description{
+\code{skrrrahh} is exactly like \code{beep} from the beepr package 
+(https://cran.r-project.org/web/packages/beepr/index.html). 
+The only difference is in the automatically loaded sounds available. 
+\code{skrrrahh} uses rap adlibs from [The Rap Board](http://therapboard.com/).
+}
+\details{
+If \code{skrrrahh} is not able to play the sound, a warning is issued rather 
+than an error. This is in order to not risk aborting or stopping the process 
+that you wanted to get notified about.
+}
+\examples{
+# Play Gucci saying "BRRR"
+skrrratt()
 \dontrun{
 # Get focused with Jay-Z.
 skrrrahh(29)
@@ -41,15 +49,3 @@ update.packages(ask=FALSE); skrrrahh(10)
 options(error = function() {skrrrahh(33)})
 }
 }
-\description{
-\code{skrrrahh} is exactly like \code{beep} from the beepr package 
-(https://cran.r-project.org/web/packages/beepr/index.html). 
-The only difference is in the automatically loaded sounds available. 
-\code{skrrrahh} uses rap adlibs from [The Rap Board](http://therapboard.com/).
-}
-\details{
-If \code{skrrrahh} is not able to play the sound, a warning is issued rather 
-than an error. This is in order to not risk aborting or stopping the process 
-that you wanted to get notified about.
-}
-


### PR DESCRIPTION
Before: 

![screen shot 2017-12-12 at 1 35 54 pm](https://user-images.githubusercontent.com/1593639/33904528-6b29a03e-df41-11e7-82f7-bc9a2d6ede13.png)

After:

![screen shot 2017-12-12 at 1 34 51 pm](https://user-images.githubusercontent.com/1593639/33904531-6d081aca-df41-11e7-9ccc-5837f95607e8.png)

Thank you for what must be one of the most valuable contributions to R in recent years.