### PR TITLE
add quotes in install.packages call

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 `BRRR` is available on Github and can be installed from within R by
 running:
 
-    if(!require(devtools)) {install.packages(devtools)}
+    if(!require(devtools)) {install.packages("devtools")}
     devtools::install_github("brooke-watson/BRRR")
 
 Requirements


### PR DESCRIPTION
minor update of README to allow for copy-pasting of installation code without error