### PR TITLE
Return the result of expr

### DIFF
--- a/R/skrrrahh.R
+++ b/R/skrrrahh.R
@@ -18,7 +18,7 @@
 #'  supported.
 #'@param expr An optional expression to be executed before the sound.
 #'
-#'@return NULL 
+#'@return The result of \code{expr}
 #'
 #' @examples 
 #' # Play Gucci saying "BRRR"
@@ -46,7 +46,7 @@
 #' }
 #'@export
 skrrrahh <- function(sound=27, expr = NULL) {
-  expr
+  result <- expr
   sounds <- skrrrahh_sounds()
   sound_path <- NULL
   if(is.na(sounds[sound]) || length(sounds[sound]) != 1) {
@@ -78,6 +78,7 @@ skrrrahh <- function(sound=27, expr = NULL) {
   tryCatch(play_file(sound_path), error = function(ex) {
     warning("BRRR() could not play the sound due to the following error:\n", ex)
   })
+  return(result)
 }
 
 skrrrahh_sounds <- function() {


### PR DESCRIPTION
It would be convenient to use `skrrrahh()` to wrap a function call, get the audio notification, and then return the result of the function call. Currently, the `skrrrahh()` returns an audio player instance. For example:
```r
hello_wait <- function(x) {
  Sys.sleep(x)
  return("Hello, world!")
}
result <- BRRR::skrrrahh(
  sound = 2,
  expr = hello_wait(5)
)
result
# Audio player instance 5290a6c0 of AudioUnits (Mac OS X) driver (macosx)
```

This commit fixes the behavior so that `result` is `"Hello, world!"`.